### PR TITLE
Add a logging adapter to append a correlation id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-  - "2.7"
   - "3.3"
+  - "3.9"
 
 install: pip install -r requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.3"
   - "3.9"
 
 install: pip install -r requirements.txt

--- a/flog/__init__.py
+++ b/flog/__init__.py
@@ -1,6 +1,6 @@
-from .flog import get_logger, log_call, log_sensitive_call
+from .flog import CorrelationLoggerAdapter, get_logger, log_call, log_sensitive_call
 
 __version__ = "0.2.1"
 __description__ = "Fast access to some simple python logging tricks"
 
-__all__ = ['get_logger', 'log_call', 'log_sensitive_call']
+__all__ = ["CorrelationLoggerAdapter", "get_logger", "log_call", "log_sensitive_call"]

--- a/flog/flog.py
+++ b/flog/flog.py
@@ -1,6 +1,14 @@
-from functools import wraps
 import logging
 import os
+import uuid
+from functools import wraps
+
+
+class CorrelationLoggerAdapter(logging.LoggerAdapter):
+    def process(self, msg, kwargs):
+        if "correlation_id" in self.extra:
+            msg = "[{}] {}".format(self.extra["correlation_id"], msg)
+        return msg, kwargs
 
 
 def __get_func_name(func, args):
@@ -9,8 +17,8 @@ def __get_func_name(func, args):
     except AttributeError:
         try:
             # try to calculate it from its class
-            qualname = '{}.{}'.format(func.im_self.__class__.__name__, func.__name__)
-        except:
+            qualname = "{}.{}".format(func.im_self.__class__.__name__, func.__name__)
+        except Exception:
             # give up and just puke it out
             qualname = func.__name__
     return qualname
@@ -23,17 +31,20 @@ def __get_log_function(logger):
         return logger.debug
 
 
-def get_logger(name):
+def get_logger(name, add_correlation_id=False):
     """Gets a logger
 
     Arguments:
         name - the name you wish to log as
+        add_correlation_id - wraps a logger with an adapter that will add a uuid4 to each log record
 
     Returns:
         A logger!
     """
     logger = logging.getLogger(name)
     logger.addHandler(logging.NullHandler())
+    if add_correlation_id:
+        return CorrelationLoggerAdapter(logger, {"correlation_id": str(uuid.uuid4())})
     return logger
 
 
@@ -43,14 +54,16 @@ def _log_call(logger):
     def decorator(function):
         @wraps(function)
         def wrapper(*args, **kwargs):
-            full_function_name = '{}.{}'.format(function.__module__, __get_func_name(function, args))
-            log_function('{}: args: {}, kwargs: {}'.format(full_function_name, args, kwargs))
+            full_function_name = "{}.{}".format(function.__module__, __get_func_name(function, args))
+            log_function("{}: args: {}, kwargs: {}".format(full_function_name, args, kwargs))
             # If you're debugging, you'll want to step into that thing down there
             retval = function(*args, **kwargs)
             # If you're debugging and wanted to hit the function and haven't yet, it's already too late!
-            log_function('{}: returns: {}'.format(full_function_name, retval))
+            log_function("{}: returns: {}".format(full_function_name, retval))
             return retval
+
         return wrapper
+
     return decorator
 
 
@@ -60,17 +73,20 @@ def _log_sensitive_call(logger):
     def decorator(function):
         @wraps(function)
         def wrapper(*args, **kwargs):
-            full_function_name = '{}.{}'.format(function.__module__, __get_func_name(function, args))
-            log_function('{}: args: *XXXXXX, kwargs: **XXXXXXX'.format(full_function_name))
+            full_function_name = "{}.{}".format(function.__module__, __get_func_name(function, args))
+            log_function("{}: args: *XXXXXX, kwargs: **XXXXXXX".format(full_function_name))
             # If you're debugging, you'll want to step into that thing down there
             retval = function(*args, **kwargs)
             # If you're debugging and wanted to hit the function and haven't yet, it's already too late!
-            log_function('{}: returns: XXXXXXXXXX'.format(full_function_name))
+            log_function("{}: returns: XXXXXXXXXX".format(full_function_name))
             return retval
+
         return wrapper
+
     return decorator
 
-if not __debug__ or os.environ.get('FLOG_NOWRAP', False):
+
+if not __debug__ or os.environ.get("FLOG_NOWRAP", False):
     log_call = log_sensitive_call = lambda logger: lambda function: function
 else:
     log_call = _log_call

--- a/flog/tests/test_get_logger.py
+++ b/flog/tests/test_get_logger.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import logging
 import random
 import unittest
-
-from mock import patch
+import uuid
 
 from flog import flog  # SUT
+from mock import patch
 
 
-@patch('flog.flog.logging')
+@patch("flog.flog.logging")
 class TestGetLogger(unittest.TestCase):
-
     def test_get_logger_gets_logger(self, logging):
         """flog.flog.get_logger: Gets a logger from the standard library"""
-        name = random.choice(['bunny', 'ninja', 'soup.pants.mcgillicutty'])
+        name = random.choice(["bunny", "ninja", "soup.pants.mcgillicutty"])
 
         actual = flog.get_logger(name)
 
@@ -22,6 +22,27 @@ class TestGetLogger(unittest.TestCase):
 
     def test_get_logger_adds_null_handler(self, logging):
         """flog.flog.get_logger: Adds a null logger to the logger in question,
-            avoiding "Unconfigured logger" exceptions """
-        flog.get_logger('_')
+        avoiding "Unconfigured logger" exceptions"""
+        flog.get_logger("_")
         logging.getLogger.return_value.addHandler.assert_called_once_with(logging.NullHandler())
+
+    def test_get_logger_with_correlation_gets_adapter(self, logging):
+        """flog.flog.get_logger: Can optionally wrap the logger with an adapter
+        that adds an id to each log record"""
+        actual = flog.get_logger("_", add_correlation_id=True)
+        self.assertIsInstance(actual, flog.CorrelationLoggerAdapter)
+
+
+@patch("flog.flog.get_logger")
+class TestCorrelationLoggerAdapter(unittest.TestCase):
+    def test_adapter_adds_correlation_id(self, get_logger):
+        """flog.flog.CorrelationLoggerAdapter.process: Appends provided correlation id to log record"""
+        cid = str(uuid.uuid4())
+        msg = random.choice(["bunny", "ninja", "soup.pants.mcgillicutty"])
+        logger = get_logger("_")
+
+        # SUT
+        logger_adapter = flog.CorrelationLoggerAdapter(logger, {"correlation_id": cid})
+        logger_adapter.debug(msg)
+
+        logger.log.assert_called_once_with(logging.DEBUG, "[{}] {}".format(cid, msg))

--- a/flog/tests/test_log_call.py
+++ b/flog/tests/test_log_call.py
@@ -3,18 +3,16 @@
 import random
 import unittest
 
-from mock import MagicMock, NonCallableMock, patch
-
 from flog import flog  # SUT
+from mock import MagicMock, NonCallableMock, patch
 
 
 def my_fun(*args, **kwargs):
     return sum(args)
 
 
-@patch('flog.flog.logging')
+@patch("flog.flog.logging")
 class TestLogCall(unittest.TestCase):
-
     def setUp(self):
         self.logger = NonCallableMock()
         # self.logger.debug = MagicMock()
@@ -39,12 +37,9 @@ class TestLogCall(unittest.TestCase):
 
         flog.log_call(self.logger)(my_fun)(randoa, randob, randoc)  # SUT
 
-        self.logger.debug.assert_any_call("test_log_call.my_fun: args: ({}, {}, {}), kwargs: {}".format(
-            randoa,
-            randob,
-            randoc,
-            '{}'
-        ))
+        self.logger.debug.assert_any_call(
+            "test_log_call.my_fun: args: ({}, {}, {}), kwargs: {}".format(randoa, randob, randoc, "{}")
+        )
         self.logger.debug.assert_any_call("test_log_call.my_fun: returns: {}".format(randoa + randob + randoc))
 
     def test_log_call_logs_with_kwargs(self, logging):
@@ -56,12 +51,11 @@ class TestLogCall(unittest.TestCase):
 
         flog.log_call(self.logger)(my_fun)(randoa, randob, randoc, random_frippery_scale=32)  # SUT
 
-        self.logger.debug.assert_any_call("test_log_call.my_fun: args: ({}, {}, {}), kwargs: {rfs}".format(
-            randoa,
-            randob,
-            randoc,
-            rfs="{'random_frippery_scale': 32}"
-        ))
+        self.logger.debug.assert_any_call(
+            "test_log_call.my_fun: args: ({}, {}, {}), kwargs: {rfs}".format(
+                randoa, randob, randoc, rfs="{'random_frippery_scale': 32}"
+            )
+        )
         self.logger.debug.assert_any_call("test_log_call.my_fun: returns: {}".format(randoa + randob + randoc))
 
     def test_log_call_logs_instance_method_with_kwargs(self, logging):
@@ -75,10 +69,7 @@ class TestLogCall(unittest.TestCase):
 
         self.logger.debug.assert_any_call(
             "test_log_call.TestLogCall.instance_method: args: ({}, {}, {}), kwargs: {rfs}".format(
-                randoa,
-                randob,
-                randoc,
-                rfs="{'random_frippery_scale': 32}"
+                randoa, randob, randoc, rfs="{'random_frippery_scale': 32}"
             )
         )
         self.logger.debug.assert_any_call(
@@ -98,10 +89,7 @@ class TestLogCall(unittest.TestCase):
 
         my_logger.assert_any_call(
             "test_log_call.TestLogCall.instance_method: args: ({}, {}, {}), kwargs: {rfs}".format(
-                randoa,
-                randob,
-                randoc,
-                rfs="{'random_frippery_scale': 32}"
+                randoa, randob, randoc, rfs="{'random_frippery_scale': 32}"
             )
         )
         my_logger.assert_any_call(
@@ -109,9 +97,8 @@ class TestLogCall(unittest.TestCase):
         )
 
 
-@patch('flog.flog.logging')
+@patch("flog.flog.logging")
 class TestLogSensitiveCall(unittest.TestCase):
-
     def setUp(self):
         self.logger = NonCallableMock()
 

--- a/setup.py
+++ b/setup.py
@@ -8,23 +8,23 @@ except ImportError:
     from distutils.core import setup
 
 packages = [
-    'flog',
+    "flog",
 ]
 
 requires = []
 
 setup(
-    name='flog',
+    name="flog",
     version=flog.__version__,
     description=flog.__description__,
-    long_description=open('README.rst').read(),
-    author='Chris McGraw',
-    author_email='mitgr81+flog@mitgr81.com',
-    url='https://github.com/mitgr81/flog',
-    test_suite='flog.tests',
+    long_description=open("README.rst").read(),
+    author="Chris McGraw",
+    author_email="mitgr81+flog@mitgr81.com",
+    url="https://github.com/mitgr81/flog",
+    test_suite="flog.tests",
     packages=packages,
-    package_dir={'flog': 'flog'},
-    package_data={'': ['LICENSE', 'README.rst']},
+    package_dir={"flog": "flog"},
+    package_data={"": ["LICENSE", "README.rst"]},
     include_package_data=True,
     install_requires=requires,
     license="MIT",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py3
+envlist = py3
 
 [testenv]
 deps = -rrequirements.txt


### PR DESCRIPTION
Add a custom logging adapter class that can be used to append a value from a `correlation_id` key from an extra info dict given to the adapter upon creating a new instance of the class.  The value from the `correlation_id` will be appended, in square brackets, to each log statement that the adapter processes.

For those who would like to quickly get a logger that will have _something_ added as a way to correlate logs, I've added a flag to `get_logger` to wrap the logger in a `CorrelationLoggerAdapter` with a uuid4 given as a correlation id for that adapter instance.

I've changed a few other items as well:
1. Drop python 2.7 from tox's envlist and the Travis CI job.
2. Add python 3.9 to the Travis CI job.  I've kept 3.3 in there for now, but 3.3 is old enough that it should be considered for removal.
3. Run the `black` formatter over the python code.  I haven't added a `pyproject.toml` file with a section to configure black, but I can add that to this PR if desired.