### PR TITLE
Run tests for Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Adds Python 3.11 to the list of Python versions for which unit tests will be run.